### PR TITLE
Fixed PlexAPI installation when permission denied

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,10 @@ def install(packages):
             packages(list<str>): Packages to install, in requirements.txt format
     """
     for package in packages:
-        subprocess.call([sys.executable, "-m", "pip", "install", "--upgrade", package])
+        try:
+            subprocess.check_output([sys.executable, "-m", "pip", "install", "--upgrade", package])
+        except subprocess.CalledProcessError:
+            subprocess.check_output([sys.executable, "-m", "pip", "install", "--upgrade", "--user", package])
 
 
 def getListFromFile(file, ignoreStart="#"):


### PR DESCRIPTION
I got an error when trying to install PlexAPI a venv, this should fix it.

```
ERROR: Could not install packages due to an EnvironmentError: [Errno 13] Permission denied: '/usr/local/lib/python3.6/dist-packages/plexapi'
Consider using the `--user` option or check the permissions.
```

I only changed the subprocess call so it checks the output,
catch the error and run it again with "--user" instead.