### PR TITLE
Change to incorporate pyreadline3 instead of pyreadline

### DIFF
--- a/plex_set_tracks.py
+++ b/plex_set_tracks.py
@@ -16,7 +16,7 @@ except ImportError:
     try:
         import readline
     except ImportError:
-        import pyreadline as readline
+        import pyreadline3 as readline
 
 
 ###############################################################################

--- a/resources/windows.txt
+++ b/resources/windows.txt
@@ -1,2 +1,2 @@
 -r requirements.txt
-pyreadline>=2.1
+pyreadline3>=3.4.1


### PR DESCRIPTION
#### Changed pyreadline to pyreadline3. Pyreadline no longer works in windows with python3.10

#### Modified the requirements for windows to pyrteadline3 and changes the main plex_set_track.py from import pyreadline to pyreadline3